### PR TITLE
Fix for iOS 18, openURL

### DIFF
--- a/iOS_SDK/Pushwoosh/Pushwoosh/Utils/Mobile/PWUtils.ios.m
+++ b/iOS_SDK/Pushwoosh/Pushwoosh/Utils/Mobile/PWUtils.ios.m
@@ -28,7 +28,7 @@
 }
 
 + (void)applicationOpenURL:(NSURL *)url {
-	[[UIApplication sharedApplication] openURL:url];
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 }
 
 + (UIButton *)webViewCloseButton {


### PR DESCRIPTION
openURL was depreciated and UIApplication.shared.open(url) was bugged in iOS 18. 

Temporary fix until Apple updates iOS 18 to fix the bug